### PR TITLE
Altda options

### DIFF
--- a/main.star
+++ b/main.star
@@ -136,6 +136,7 @@ def run(plan, args):
                 persistent,
                 observability_helper,
                 interop_params,
+                altda_deploy_config,
             )
         )
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -35,12 +35,9 @@ optimism_package:
         fjord_time_offset: 0
         granite_time_offset: 0
         fund_dev_accounts: false
-
-        
         withdrawal_delay: 604800 # should not be 0
         fee_withdrawal_network: 0 # 0 or 1 for either l1 or l2
         dispute_game_finality_delay: 302400 # should not be 0
-
       batcher_params:
         private_key: "e7848b12992369c383cfbff59633aeb305dbbd7a2c2ca19e60cc514dd953aefa"
         #signer_address: '0xD0e9d614E8d5C5C3e7F09Dcb31CB3A7552deC836'
@@ -71,7 +68,12 @@ optimism_package:
       mev_params:
         builder_host: ""
         builder_port: ""
-      additional_services: []
+      additional_services: ["da_server"]
+
+      da_server_params:
+        # only if custom da_type selected in altda_deploy_config
+        server_endpoint: "https://celestia-mocha-rpc.publicnode.com:443"
+
   op_contract_deployer_params:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.12
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
@@ -80,6 +82,31 @@ optimism_package:
   global_node_selectors: {}
   global_tolerations: []
   persistent: false
+
+  altda_deploy_config:
+    use_altda: true
+    # TODO: Is this field redundant? Afaiu setting it to GenericCommitment will not deploy the
+    # DAChallengeContract, and hence is equivalent to setting use_altda to false.
+    # Furthermore, altda rollups using generic commitments might anyways need to support failing over
+    # to keccak commitments if the altda layer is down.
+
+    #da_provider: # not sure what this is from the docs https://docs.optimism.io/operators/chain-operators/configuration/rollup#gaspriceoraclebasefeescalar
+    
+    da_type: "" # auto, blobs, calldata or CUSTOM sets --data-availability-type in batcher_launcher
+    da_batch_submission_frequency: 1 #--max-channel-duration=1 in block units but user input in minutes
+
+
+    # below only if custom da selected
+    da_commitment_type: KeccakCommitment # select either generic or Keccack
+    
+    # if select generic ask for da challenge contract address
+    da_challenge_contract_address: "0x49cce536156dC6E5F05B26eaA8a2607Cb943e041"
+
+    da_challenge_window: 100
+    da_resolve_window: 100
+    da_bond_size: 10000
+    da_resolver_refund_percentage: 0
+
 external_l1_network_params:
   network_id: "3151908"
   rpc_kind: standard

--- a/src/alt-da/da-server/da_server_launcher.star
+++ b/src/alt-da/da-server/da_server_launcher.star
@@ -1,65 +1,12 @@
-shared_utils = import_module(
-    "github.com/ethpandaops/ethereum-package/src/shared_utils/shared_utils.star"
-)
-constants = import_module(
-    "github.com/ethpandaops/ethereum-package/src/package_io/constants.star"
-)
-
-# Port IDs
-DA_SERVER_HTTP_PORT_ID = "http"
-
-# Port nums
-DA_SERVER_HTTP_PORT_NUM = 3100
-
-
-def get_used_ports():
-    used_ports = {
-        DA_SERVER_HTTP_PORT_ID: shared_utils.new_port_spec(
-            DA_SERVER_HTTP_PORT_NUM,
-            shared_utils.TCP_PROTOCOL,
-            shared_utils.HTTP_APPLICATION_PROTOCOL,
-        ),
-    }
-    return used_ports
-
-
-def launch_da_server(
+def get_enabled_da_server_context(
     plan,
     service_name,
-    image,
-    cmd,
+    server_endpoint,
 ):
-    config = get_da_server_config(
-        plan,
-        service_name,
-        image,
-        cmd,
-    )
-
-    da_server_service = plan.add_service(service_name, config)
-
-    http_url = "http://{0}:{1}".format(
-        da_server_service.ip_address, DA_SERVER_HTTP_PORT_NUM
-    )
-    # da_server_context is passed as argument to op-batcher and op-node(s)
+    plan.print("Server endpoint: {0}".format(server_endpoint))
+    # if using "custom" da-type, the server endpoint is provided
     return new_da_server_context(
-        http_url=http_url,
-    )
-
-
-def get_da_server_config(
-    plan,
-    service_name,
-    image,
-    cmd,
-):
-    ports = get_used_ports()
-
-    return ServiceConfig(
-        image=image,
-        ports=ports,
-        cmd=cmd,
-        private_ip_address_placeholder=constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        http_url=server_endpoint,
     )
 
 

--- a/src/l2.star
+++ b/src/l2.star
@@ -22,6 +22,7 @@ def launch_l2(
     persistent,
     observability_helper,
     interop_params,
+    altda_deploy_config,
 ):
     network_params = l2_args.network_params
     batcher_params = l2_args.batcher_params
@@ -35,15 +36,13 @@ def launch_l2(
     # because op-batcher and op-node(s) need to know the da-server url, if present
     da_server_context = da_server_launcher.disabled_da_server_context()
     if "da_server" in l2_args.additional_services:
-        da_server_image = l2_args.da_server_params.image
-        plan.print("Launching da-server")
-        da_server_context = da_server_launcher.launch_da_server(
+        plan.print("Adding da-server endpoint")
+        da_server_context = da_server_launcher.get_enabled_da_server_context(
             plan,
             "da-server-{0}".format(l2_services_suffix),
-            da_server_image,
-            l2_args.da_server_params.cmd,
+            l2_args.da_server_params.server_endpoint,
         )
-        plan.print("Successfully launched da-server")
+        plan.print("Successfully added da-server endpoint")
 
     l2 = participant_network.launch_participant_network(
         plan,
@@ -66,6 +65,7 @@ def launch_l2(
         observability_helper,
         interop_params,
         da_server_context,
+        altda_deploy_config,
     )
 
     all_el_contexts = []

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -560,11 +560,14 @@ def default_interop_params():
 def default_altda_deploy_config():
     return {
         "use_altda": False,
+        "da_type": "blobs",
         "da_commitment_type": "KeccakCommitment",
         "da_challenge_window": 100,
         "da_resolve_window": 100,
         "da_bond_size": 0,
         "da_resolver_refund_percentage": 0,
+        "da_batch_submission_frequency": 1,
+        "da_challenge_contract_address": "",
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -43,18 +43,8 @@ DEFAULT_SIDECAR_IMAGES = {
 }
 
 DEFAULT_DA_SERVER_PARAMS = {
-    "image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:latest",
-    "cmd": [
-        "da-server",  # uses keccak commitments by default
-        # We use the file storage backend instead of s3 for simplicity.
-        # Blobs and commitments are stored in the /home directory (which already exists).
-        # Note that this storage is ephemeral because we aren't mounting an external kurtosis file.
-        # This means that the data is lost when the container is deleted.
-        "--file.path=/home",
-        "--addr=0.0.0.0",
-        "--port=3100",
-        "--log.level=debug",
-    ],
+    "enabled": False,
+    "server_endpoint": "",
 }
 
 
@@ -127,6 +117,13 @@ def input_parser(plan, input_args, deployment_type):
             da_bond_size=results["altda_deploy_config"]["da_bond_size"],
             da_resolver_refund_percentage=results["altda_deploy_config"][
                 "da_resolver_refund_percentage"
+            ],
+            da_type=results["altda_deploy_config"]["da_type"],
+            da_batch_submission_frequency=results["altda_deploy_config"][
+                "da_batch_submission_frequency"
+            ],
+            da_challenge_contract_address=results["altda_deploy_config"][
+                "da_challenge_contract_address"
             ],
         ),
         chains=[
@@ -275,8 +272,7 @@ def input_parser(plan, input_args, deployment_type):
                 ),
                 da_server_params=struct(
                     enabled=result["da_server_params"]["enabled"],
-                    image=result["da_server_params"]["image"],
-                    cmd=result["da_server_params"]["cmd"],
+                    server_endpoint=result["da_server_params"]["server_endpoint"],
                 ),
                 additional_services=result["additional_services"],
             )
@@ -810,8 +806,7 @@ def default_ethereum_package_network_params():
 def default_da_server_params():
     return {
         "enabled": False,
-        "image": DEFAULT_DA_SERVER_PARAMS["image"],
-        "cmd": DEFAULT_DA_SERVER_PARAMS["cmd"],
+        "server_endpoint": "",
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -41,6 +41,9 @@ ALTDA_DEPLOY_CONFIG_PARAMS = [
     "da_resolve_window",
     "da_bond_size",
     "da_resolver_refund_percentage",
+    "da_type",
+    "da_batch_submission_frequency",
+    "da_challenge_contract_address",
 ]
 
 PARTICIPANT_CATEGORIES = {
@@ -166,8 +169,7 @@ SUBCATEGORY_PARAMS = {
     "mev_params": ["rollup_boost_image", "builder_host", "builder_port"],
     "da_server_params": [
         "enabled",
-        "image",
-        "cmd",
+        "server_endpoint",
     ],
 }
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -30,6 +30,7 @@ def launch_participant_network(
     observability_helper,
     interop_params,
     da_server_context,
+    altda_deploy_config,
 ):
     num_participants = len(participants)
     # First EL and sequencer CL
@@ -92,6 +93,7 @@ def launch_participant_network(
         batcher_params,
         observability_helper,
         da_server_context,
+        altda_deploy_config,
     )
 
     game_factory_address = util.read_network_config_value(


### PR DESCRIPTION
Allows configuration of data availability and for alternative data availability

Allows customisations of

- da type (call-data, blobs, auto and custom)
- da batch submission frequency

If the da type is custom, configurations of altda is allowed

- altda server endpoint
- altda commitment type
- challenge contract address
- challenge window
- resolve window
- bond size
- refund percentage