### PR TITLE
fix: underlying ethereum package latest commit appears broken

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,7 @@ jobs:
           kurtosis analytics disable
 
       - name: Deploy L1
-        run: kurtosis run --enclave test --args-file ./.github/tests/external-l1/ethereum.yaml github.com/ethpandaops/ethereum-package
+        run: kurtosis run --enclave test --args-file ./.github/tests/external-l1/ethereum.yaml github.com/ethpandaops/ethereum-package@cb644aff035c6883575959ee50a64eef83615486
 
       - name: Run Starlark
         run: |


### PR DESCRIPTION
- [Ethereum Package](https://github.com/ethpandaops/ethereum-package/commits/main/) latest commit hash `37082b2253e3df3526cd96f48858d43bfadb9ebf` appears to no longer work with the current `config.yaml` they use.
- run_with_external_l1_args test relies on launching a separate L1 chain using the ethereum package. However it no longer can
- Instead using the previous commit version in the test which does not have this problem
- Seems like a better solution to fix the ethereum package commit so future changes from it no longer affect UpRoll